### PR TITLE
Make goimport go-mod-aware

### DIFF
--- a/goimport.go
+++ b/goimport.go
@@ -356,11 +356,14 @@ func addPackage(fset *token.FileSet, file *ast.File, pkg string, opts options, r
 }
 
 func goget(pkg string) error {
-	return exec.Command("go", "get", pkg).Run()
+	cmd := exec.Command("go", "get", pkg)
+	cmd.Env = os.Environ()
+	return cmd.Run()
 }
 
 func exists(pkg string) bool {
 	cmd := exec.Command("go", "list", pkg)
+	cmd.Env = os.Environ()
 	return cmd.Run() == nil
 }
 


### PR DESCRIPTION
[Go modules](https://github.com/golang/go/wiki/Modules) are becoming de-facto standard for dependency management and this patch is necessary to make it work with Go imports in a go-mod-aware repository, otherwise `go list` fails as it's attempting to look for package in `GOPATH`.

```
$ goimport -w -replace github.com/google/go-github/v21/github ./github/config.go
goimport: import 'github.com/google/go-github/v21/github' is not in GOPATH
```
