### PR TITLE
Fix json parser

### DIFF
--- a/goimport.go
+++ b/goimport.go
@@ -182,7 +182,9 @@ func rewrite(filename string, src []byte, opts options) ([]byte, error) {
 
 			// package
 			case *ast.Ident:
-				start = int(x.End()) + 1
+				if start == 0 {
+					start = int(x.End()) + 1
+				}
 
 			case *ast.FuncDecl:
 				return false

--- a/goimport_test.go
+++ b/goimport_test.go
@@ -297,6 +297,12 @@ func TestRewrite(t *testing.T) {
 			"",
 		},
 		{
+			options{add: StringList{"errors"}, json: true},
+			"package main\nimport (\n\tf \"fmt\"\n)",
+			`{"start":14,"end":33,"code":"import (\n\tf \"fmt\"\n\t\"errors\"\n)"}`,
+			"",
+		},
+		{
 			options{json: true, add: StringList{"io"}},
 			`
 package main


### PR DESCRIPTION
When I run `goimport -add "errors" -json` for below file.

```go
package main

import (
    f "fmt"
)
```

Before: `{"start":26,"end":33,"code":"import (\n\tf \"fmt\"\n\t\"errors\"\n)"}`
After: `{"start":14,"end":33,"code":"import (\n\tf \"fmt\"\n\t\"errors\"\n)"}`